### PR TITLE
Add Markdown documentation for benchmark source files

### DIFF
--- a/Benchmark/src/Benchmark.h.md
+++ b/Benchmark/src/Benchmark.h.md
@@ -1,0 +1,52 @@
+# Benchmark.h
+
+## Overview
+
+This header file provides utility functions and macros for creating and running benchmarks within the OpenCatalog project. It includes functions for generating test data (vectors of zeros, uninitialized vectors, and random vectors) and a custom macro for defining benchmarks with fine-tuned settings.
+
+## Key Components
+
+*   **`OC_BENCHMARK(NAME, ...)`:** A macro that wraps the `BENCHMARK` macro from the `benchmark/benchmark.h` library. It sets the benchmark name and time unit to microseconds.
+*   **`CreateZeroVector<Ty>(n)`:** A template function that returns a `std::vector<Ty>` of size `n` filled with zeros.
+*   **`CreateUninitializedVector<Ty>(n)`:** A template function that returns an uninitialized `std::vector<Ty>` of size `n`.
+*   **`CreateRandomVector<Ty>(n, lowerBound, upperBound)`:** A template function that returns a `std::vector<Ty>` of size `n` filled with random floating-point numbers uniformly distributed between `lowerBound` (default 1) and `upperBound` (default 128).
+
+## Important Variables/Constants
+
+*   None explicitly defined in this file that globally affect behavior outside of function parameters.
+
+## Usage Examples
+
+```cpp
+#include "Benchmark.h"
+#include <vector>
+
+// Example of using CreateRandomVector
+static void BM_MyRandomVectorUsage(benchmark::State& state) {
+  for (auto _ : state) {
+    std::vector<float> v = OpenCatalog::CreateRandomVector<float>(1000);
+    // Process the vector v
+    benchmark::DoNotOptimize(v.data());
+  }
+}
+OC_BENCHMARK("MyRandomVectorBenchmark", BM_MyRandomVectorUsage);
+
+// Example of using CreateZeroVector
+static void BM_MyZeroVectorUsage(benchmark::State& state) {
+  for (auto _ : state) {
+    std::vector<int> v = OpenCatalog::CreateZeroVector<int>(500);
+    // Process the vector v
+    benchmark::DoNotOptimize(v.data());
+  }
+}
+OC_BENCHMARK("MyZeroVectorBenchmark", BM_MyZeroVectorUsage);
+```
+
+## Dependencies and Interactions
+
+*   **`<algorithm>`:** Used for `std::generate` in `CreateRandomVector`.
+*   **`<random>`:** Used for random number generation (`std::mt19937`, `std::uniform_real_distribution`) in `CreateRandomVector`.
+*   **`<vector>`:** Used for `std::vector` data structures.
+*   **`benchmark/benchmark.h`:** This file heavily relies on the Google Benchmark library for its core functionality. The `OC_BENCHMARK` macro is a customization of the library's `BENCHMARK` macro.
+*   Interacts with benchmark source files (`.cpp`) that will include this header to define and run specific benchmarks.
+```

--- a/Benchmark/src/PWR003.cpp.md
+++ b/Benchmark/src/PWR003.cpp.md
@@ -1,0 +1,47 @@
+# PWR003.cpp
+
+## Overview
+
+This file defines benchmarks for `PWR003`, which likely relates to a specific performance optimization pattern or check. It benchmarks C and Fortran implementations of an "example" version and an "improved" (solution) version of a particular computation. The computation involves calculating weights based on masses.
+
+## Key Components
+
+*   **`example(N, masses, weights)`:** (Extern "C") A C function (presumably defined elsewhere) representing the original version of the computation.
+*   **`solution(N, masses, weights)`:** (Extern "C") A C function (presumably defined elsewhere) representing the improved/optimized version of the computation.
+*   **`example_f(N, masses, weights)`:** (Extern "C") A Fortran function (presumably defined elsewhere) representing the original Fortran version of the computation.
+*   **`solution_f(N, masses, weights)`:** (Extern "C") A Fortran function (presumably defined elsewhere) representing the improved/optimized Fortran version of the computation.
+*   **`CExampleBench(state)`:** A benchmark function that measures the performance of the `example` C function.
+*   **`CImprovedBench(state)`:** A benchmark function that measures the performance of the `solution` C function.
+*   **`FortranExampleBench(state)`:** A benchmark function that measures the performance of the `example_f` Fortran function.
+*   **`FortranImprovedBench(state)`:** A benchmark function that measures the performance of the `solution_f` Fortran function.
+
+## Important Variables/Constants
+
+*   **`N` (constexpr int):** Defines the size of the input arrays for the benchmark, set to `128 * 128 * 128`. This size is chosen to ensure benchmarks run for a duration measurable in microseconds.
+*   **`OCB_ENABLE_C` (preprocessor macro):** If defined and true, the C benchmarks (`CExampleBench`, `CImprovedBench`) are compiled and registered.
+*   **`OCB_ENABLE_Fortran` (preprocessor macro):** If defined and true, the Fortran benchmarks (`FortranExampleBench`, `FortranImprovedBench`) are compiled and registered.
+
+## Usage Examples
+
+This file is not meant to be used as a library. It's compiled as part of the benchmark executable. The benchmarks are automatically registered and run by the Google Benchmark framework.
+
+The core logic being benchmarked (e.g., `example`, `solution` functions) is defined externally. This file sets up the data for these functions and measures their execution time.
+
+```cpp
+// Within this file, benchmarks are registered like this:
+// OC_BENCHMARK("PWR003 C Example", CExampleBench);
+// OC_BENCHMARK("PWR003 C Improved", CImprovedBench);
+
+// The benchmarked functions `example` and `solution` would be used like:
+// double *masses = ...; // initialized data
+// double *weights = ...; // zeroed data
+// example(N, masses, weights); // populates weights
+```
+
+## Dependencies and Interactions
+
+*   **`Benchmark.h`:** Includes utility functions like `OpenCatalog::CreateRandomVector` and `OpenCatalog::CreateZeroVector`, and the `OC_BENCHMARK` macro.
+*   **Google Benchmark library (`benchmark/benchmark.h` via `Benchmark.h`):** Provides the framework for defining and running benchmarks.
+*   **External C/Fortran code:** The actual computations (`example`, `solution`, `example_f`, `solution_f`) are defined in other source files and linked. The `extern "C"` linkage specification is used to ensure name mangling compatibility between C++ and these external functions (which might be C or Fortran compiled to be C-compatible).
+*   The benchmarks are conditionally compiled based on `OCB_ENABLE_C` and `OCB_ENABLE_Fortran` macros, allowing selective testing of C and Fortran versions.
+```

--- a/Benchmark/src/PWR022.cpp.md
+++ b/Benchmark/src/PWR022.cpp.md
@@ -1,0 +1,48 @@
+# PWR022.cpp
+
+## Overview
+
+This file defines benchmarks for `PWR022`, related to a specific performance optimization pattern. It benchmarks C and Fortran implementations of an "example" version and an "improved" (solution) version of a computation involving four arrays A, B, C, and D.
+
+## Key Components
+
+*   **`example(n, A, B, C, D)`:** (Extern "C") A C function (defined elsewhere) representing the original version of the computation.
+*   **`solution(n, A, B, C, D)`:** (Extern "C") A C function (defined elsewhere) representing the improved/optimized version of the computation.
+*   **`example_f(n, A, B, C, D)`:** (Extern "C") A Fortran function (defined elsewhere) representing the original Fortran version of the computation.
+*   **`solution_f(n, A, B, C, D)`:** (Extern "C") A Fortran function (defined elsewhere) representing the improved/optimized Fortran version of the computation.
+*   **`CExampleBench(state)`:** A benchmark function that measures the performance of the `example` C function.
+*   **`CImprovedBench(state)`:** A benchmark function that measures the performance of the `solution` C function.
+*   **`FortranExampleBench(state)`:** A benchmark function that measures the performance of the `example_f` Fortran function.
+*   **`FortranImprovedBench(state)`:** A benchmark function that measures the performance of the `solution_f` Fortran function.
+
+## Important Variables/Constants
+
+*   **`N` (constexpr int):** Defines the primary dimension for input arrays, set to `128`. The actual sizes of arrays A, B, C, D are derived from N (e.g., N, N*N, N*N*N). This size is chosen to ensure benchmarks run for a duration measurable in microseconds.
+*   **`OCB_ENABLE_C` (preprocessor macro):** If defined and true, the C benchmarks (`CExampleBench`, `CImprovedBench`) are compiled and registered.
+*   **`OCB_ENABLE_Fortran` (preprocessor macro):** If defined and true, the Fortran benchmarks (`FortranExampleBench`, `FortranImprovedBench`) are compiled and registered.
+
+## Usage Examples
+
+This file is compiled as part of the benchmark executable. The benchmarks are automatically registered and run by the Google Benchmark framework.
+
+```cpp
+// Benchmarks are registered like this:
+// OC_BENCHMARK("PWR022 C Example", CExampleBench);
+// OC_BENCHMARK("PWR022 C Improved", CImprovedBench);
+// OC_BENCHMARK("PWR022 Fortran Example", FortranExampleBench);
+// OC_BENCHMARK("PWR022 Fortran Improved", FortranImprovedBench);
+
+// The benchmarked functions (defined externally) are used as follows:
+// const double *A, *B, *C; // initialized data
+// double *D; // uninitialized data for output
+// example(N, A, B, C, D); // example computation
+// solution(N, A, B, C, D); // improved computation
+```
+
+## Dependencies and Interactions
+
+*   **`Benchmark.h`:** Includes utility functions like `OpenCatalog::CreateRandomVector`, `OpenCatalog::CreateUninitializedVector`, and the `OC_BENCHMARK` macro.
+*   **Google Benchmark library (`benchmark/benchmark.h` via `Benchmark.h`):** Provides the core framework for defining and running benchmarks.
+*   **External C/Fortran code:** The actual computations (`example`, `solution`, `example_f`, `solution_f`) are defined in other source files and linked.
+*   Conditional compilation based on `OCB_ENABLE_C` and `OCB_ENABLE_Fortran` macros allows selective testing.
+```

--- a/Benchmark/src/PWR031.cpp.md
+++ b/Benchmark/src/PWR031.cpp.md
@@ -1,0 +1,48 @@
+# PWR031.cpp
+
+## Overview
+
+This file defines benchmarks for `PWR031`, which focuses on a numerical integration problem using the midpoint rule for the function `x^1.5 * sin(x)`. It benchmarks C and Fortran implementations of an "example" version and an "improved" (solution) version of this calculation.
+
+## Key Components
+
+*   **`midpoint_rule_x_pow_1_5_sin_x(a, b, n)`:** (Extern "C") A C function (defined elsewhere) representing the original version of the midpoint rule calculation.
+*   **`midpoint_rule_x_pow_1_5_sin_x_improved(a, b, n)`:** (Extern "C") A C function (defined elsewhere) representing the improved/optimized version of the midpoint rule calculation.
+*   **`midpoint_rule_x_pow_1_5_sin_x_f(a, b, n)`:** (Extern "C") A Fortran function (defined elsewhere) representing the original Fortran version of the midpoint rule calculation.
+*   **`midpoint_rule_x_pow_1_5_sin_x_improved_f(a, b, n)`:** (Extern "C") A Fortran function (defined elsewhere) representing the improved/optimized Fortran version of the midpoint rule calculation.
+*   **`CExampleBench(state)`:** A benchmark function that measures the performance of the `midpoint_rule_x_pow_1_5_sin_x` C function.
+*   **`CImprovedBench(state)`:** A benchmark function that measures the performance of the `midpoint_rule_x_pow_1_5_sin_x_improved` C function.
+*   **`FortranExampleBench(state)`:** A benchmark function that measures the performance of the `midpoint_rule_x_pow_1_5_sin_x_f` Fortran function.
+*   **`FortranImprovedBench(state)`:** A benchmark function that measures the performance of the `midpoint_rule_x_pow_1_5_sin_x_improved_f` Fortran function.
+
+## Important Variables/Constants
+
+*   **`a` (constexpr double):** The lower bound of the integration interval, set to `20.0`.
+*   **`b` (constexpr double):** The upper bound of the integration interval, set to `30.0`.
+*   **`n` (constexpr int):** The number of subintervals for the midpoint rule, set to `524288`. This size is chosen to ensure benchmarks run for a duration measurable in microseconds.
+*   **`OCB_ENABLE_C` (preprocessor macro):** If defined and true, the C benchmarks (`CExampleBench`, `CImprovedBench`) are compiled and registered.
+*   **`OCB_ENABLE_Fortran` (preprocessor macro):** If defined and true, the Fortran benchmarks (`FortranExampleBench`, `FortranImprovedBench`) are compiled and registered.
+
+## Usage Examples
+
+This file is compiled as part of the benchmark executable. The benchmarks are automatically registered and run by the Google Benchmark framework.
+
+```cpp
+// Benchmarks are registered like this:
+// OC_BENCHMARK("PWR031 C Example", CExampleBench);
+// OC_BENCHMARK("PWR031 C Improved", CImprovedBench);
+// OC_BENCHMARK("PWR031 Fortran Example", FortranExampleBench);
+// OC_BENCHMARK("PWR031 Fortran Improved", FortranImprovedBench);
+
+// The benchmarked functions (defined externally) are used as follows:
+// double result_example = midpoint_rule_x_pow_1_5_sin_x(a, b, n);
+// double result_improved = midpoint_rule_x_pow_1_5_sin_x_improved(a, b, n);
+```
+
+## Dependencies and Interactions
+
+*   **`Benchmark.h`:** Includes the `OC_BENCHMARK` macro and potentially other utilities (though not directly used for data generation in this specific file).
+*   **Google Benchmark library (`benchmark/benchmark.h` via `Benchmark.h`):** Provides the core framework for defining and running benchmarks.
+*   **External C/Fortran code:** The actual numerical integration functions (`midpoint_rule_x_pow_1_5_sin_x`, etc.) are defined in other source files and linked.
+*   Conditional compilation based on `OCB_ENABLE_C` and `OCB_ENABLE_Fortran` macros allows selective testing.
+```

--- a/Benchmark/src/PWR032.cpp.md
+++ b/Benchmark/src/PWR032.cpp.md
@@ -1,0 +1,41 @@
+# PWR032.cpp
+
+## Overview
+
+This file defines benchmarks for `PWR032`, which likely involves a computation using pairs of 2D coordinates (X1,Y1) and (X2,Y2) to produce a result array. It benchmarks C implementations of an "example" version and an "improved" (solution) version of this computation. Fortran versions are not included in this specific benchmark file.
+
+## Key Components
+
+*   **`example(N, X1, Y1, X2, Y2, result)`:** (Extern "C") A C function (defined elsewhere) representing the original version of the computation.
+*   **`solution(N, X1, Y1, X2, Y2, result)`:** (Extern "C") A C function (defined elsewhere) representing the improved/optimized version of the computation.
+*   **`CExampleBench(state)`:** A benchmark function that measures the performance of the `example` C function.
+*   **`CImprovedBench(state)`:** A benchmark function that measures the performance of the `solution` C function.
+
+## Important Variables/Constants
+
+*   **`N` (constexpr int):** Defines the size of the input arrays, set to `128 * 128 * 128`. This large size is chosen to ensure benchmarks run for a duration measurable in microseconds.
+*   **`OCB_ENABLE_C` (preprocessor macro):** If defined and true, the C benchmarks (`CExampleBench`, `CImprovedBench`) are compiled and registered. (Note: Fortran benchmarks are not present in this file).
+
+## Usage Examples
+
+This file is compiled as part of the benchmark executable. The benchmarks are automatically registered and run by the Google Benchmark framework.
+
+```cpp
+// Benchmarks are registered like this:
+// OC_BENCHMARK("PWR032 C Example", CExampleBench);
+// OC_BENCHMARK("PWR032 C Improved", CImprovedBench);
+
+// The benchmarked functions (defined externally) are used as follows:
+// const float *X1, *Y1, *X2, *Y2; // initialized data
+// float *result; // uninitialized data for output
+// example(N, X1, Y1, X2, Y2, result); // example computation
+// solution(N, X1, Y1, X2, Y2, result); // improved computation
+```
+
+## Dependencies and Interactions
+
+*   **`Benchmark.h`:** Includes utility functions like `OpenCatalog::CreateRandomVector`, `OpenCatalog::CreateUninitializedVector`, and the `OC_BENCHMARK` macro.
+*   **Google Benchmark library (`benchmark/benchmark.h` via `Benchmark.h`):** Provides the core framework for defining and running benchmarks.
+*   **External C code:** The actual computations (`example`, `solution`) are defined in other source files and linked.
+*   Conditional compilation based on `OCB_ENABLE_C` macro allows selective testing of C versions. No Fortran counterparts are benchmarked in this file.
+```

--- a/Benchmark/src/PWR037.cpp.md
+++ b/Benchmark/src/PWR037.cpp.md
@@ -1,0 +1,45 @@
+# PWR037.cpp
+
+## Overview
+
+This file defines benchmarks for `PWR037`, which involves computing a damped sinusoid function over a series of timesteps. It benchmarks C implementations of an "example" version and an "improved" (or "fixed") version of this computation. Fortran versions are not included.
+
+## Key Components
+
+*   **`compute_damped_sinusoid(n, timesteps, amplitude, angularFrequency, decayRate, phaseShift, results)`:** (Extern "C") A C function (defined elsewhere) representing the original version of the damped sinusoid computation.
+*   **`compute_damped_sinusoid_improved(n, timesteps, amplitude, angularFrequency, decayRate, phaseShift, results)`:** (Extern "C") A C function (defined elsewhere) representing the improved/fixed version of the computation.
+*   **`CExampleBench(state)`:** A benchmark function that measures the performance of the `compute_damped_sinusoid` C function.
+*   **`CImprovedBench(state)`:** A benchmark function that measures the performance of the `compute_damped_sinusoid_improved` C function.
+
+## Important Variables/Constants
+
+*   **`N` (constexpr int):** Defines the number of timesteps and the size of the `results` array, set to `1024 * 1024`.
+*   **`AMPLITUDE` (constexpr double):** The amplitude of the sinusoid, set to `1.0`.
+*   **`ANGULAR_FREQUENCY` (constexpr double):** The angular frequency of the sinusoid, set to `2.0`.
+*   **`DECAY_RATE` (constexpr double):** The decay rate of the sinusoid, set to `0.5`.
+*   **`PHASE_SHIFT` (constexpr double):** The phase shift of the sinusoid, set to PI/4 (`3.141592653589793 / 4`).
+*   **`OCB_ENABLE_C` (preprocessor macro):** If defined and true, the C benchmarks (`CExampleBench`, `CImprovedBench`) are compiled and registered.
+
+## Usage Examples
+
+This file is compiled as part of the benchmark executable. The benchmarks are automatically registered and run by the Google Benchmark framework.
+
+```cpp
+// Benchmarks are registered like this:
+// OC_BENCHMARK("PWR037 C Example", CExampleBench);
+// OC_BENCHMARK("PWR037 C Fixed", CImprovedBench); // Note: "Fixed" instead of "Improved"
+
+// The benchmarked functions (defined externally) are used as follows:
+// const double *timesteps; // initialized data
+// double *results; // uninitialized data for output
+// compute_damped_sinusoid(N, timesteps, AMPLITUDE, ANGULAR_FREQUENCY, DECAY_RATE, PHASE_SHIFT, results);
+// compute_damped_sinusoid_improved(N, timesteps, AMPLITUDE, ANGULAR_FREQUENCY, DECAY_RATE, PHASE_SHIFT, results);
+```
+
+## Dependencies and Interactions
+
+*   **`Benchmark.h`:** Includes utility functions like `OpenCatalog::CreateRandomVector`, `OpenCatalog::CreateUninitializedVector`, and the `OC_BENCHMARK` macro.
+*   **Google Benchmark library (`benchmark/benchmark.h` via `Benchmark.h`):** Provides the core framework for defining and running benchmarks.
+*   **External C code:** The actual damped sinusoid computations (`compute_damped_sinusoid`, `compute_damped_sinusoid_improved`) are defined in other source files and linked.
+*   Conditional compilation based on `OCB_ENABLE_C` macro allows selective testing of C versions. No Fortran counterparts are benchmarked in this file.
+```

--- a/Benchmark/src/PWR039.cpp.md
+++ b/Benchmark/src/PWR039.cpp.md
@@ -1,0 +1,48 @@
+# PWR039.cpp
+
+## Overview
+
+This file defines benchmarks for `PWR039`, which focuses on matrix multiplication (`C = A * B`). It benchmarks C and Fortran implementations of an "example" version and an "improved" (solution) version of this common linear algebra operation.
+
+## Key Components
+
+*   **`matmul(n, A, B, C)`:** (Extern "C") A C function (defined elsewhere) representing the original version of the matrix multiplication.
+*   **`matmul_improved(n, A, B, C)`:** (Extern "C") A C function (defined elsewhere) representing the improved/optimized version of the matrix multiplication.
+*   **`matmul_f(n, A, B, C)`:** (Extern "C") A Fortran function (defined elsewhere) representing the original Fortran version of the matrix multiplication.
+*   **`matmul_improved_f(n, A, B, C)`:** (Extern "C") A Fortran function (defined elsewhere) representing the improved/optimized Fortran version of the matrix multiplication.
+*   **`CExampleBench(state)`:** A benchmark function that measures the performance of the `matmul` C function.
+*   **`CImprovedBench(state)`:** A benchmark function that measures the performance of the `matmul_improved` C function.
+*   **`FortranExampleBench(state)`:** A benchmark function that measures the performance of the `matmul_f` Fortran function.
+*   **`FortranImprovedBench(state)`:** A benchmark function that measures the performance of the `matmul_improved_f` Fortran function.
+
+## Important Variables/Constants
+
+*   **`N` (constexpr int):** Defines the dimension of the square matrices (N x N), set to `128`. The total number of elements in each matrix is `N * N`.
+*   **`OCB_ENABLE_C` (preprocessor macro):** If defined and true, the C benchmarks (`CExampleBench`, `CImprovedBench`) are compiled and registered.
+*   **`OCB_ENABLE_Fortran` (preprocessor macro):** If defined and true, the Fortran benchmarks (`FortranExampleBench`, `FortranImprovedBench`) are compiled and registered.
+
+## Usage Examples
+
+This file is compiled as part of the benchmark executable. The benchmarks are automatically registered and run by the Google Benchmark framework.
+
+```cpp
+// Benchmarks are registered like this:
+// OC_BENCHMARK("PWR039 C Example", CExampleBench);
+// OC_BENCHMARK("PWR039 C Improved", CImprovedBench);
+// OC_BENCHMARK("PWR039 Fortran Example", FortranExampleBench);
+// OC_BENCHMARK("PWR039 Fortran Improved", FortranImprovedBench);
+
+// The benchmarked functions (defined externally) are used as follows:
+// const double *A, *B; // initialized input matrices
+// double *C; // zero-initialized output matrix
+// matmul(N, A, B, C); // example matrix multiplication
+// matmul_improved(N, A, B, C); // improved matrix multiplication
+```
+
+## Dependencies and Interactions
+
+*   **`Benchmark.h`:** Includes utility functions like `OpenCatalog::CreateRandomVector`, `OpenCatalog::CreateZeroVector`, and the `OC_BENCHMARK` macro.
+*   **Google Benchmark library (`benchmark/benchmark.h` via `Benchmark.h`):** Provides the core framework for defining and running benchmarks.
+*   **External C/Fortran code:** The actual matrix multiplication functions (`matmul`, `matmul_improved`, etc.) are defined in other source files and linked.
+*   Conditional compilation based on `OCB_ENABLE_C` and `OCB_ENABLE_Fortran` macros allows selective testing.
+```

--- a/Benchmark/src/PWR043.cpp.md
+++ b/Benchmark/src/PWR043.cpp.md
@@ -1,0 +1,48 @@
+# PWR043.cpp
+
+## Overview
+
+This file defines benchmarks for `PWR043`, which, similar to `PWR039`, focuses on matrix multiplication (`C = A * B`). It benchmarks C and Fortran implementations of an "example" version and an "improved" (solution) version of this operation. The result matrix `C` is initialized as uninitialized memory.
+
+## Key Components
+
+*   **`matmul(n, A, B, C)`:** (Extern "C") A C function (defined elsewhere) representing the original version of the matrix multiplication.
+*   **`matmul_improved(n, A, B, C)`:** (Extern "C") A C function (defined elsewhere) representing the improved/optimized version of the matrix multiplication.
+*   **`matmul_f(n, A, B, C)`:** (Extern "C") A Fortran function (defined elsewhere) representing the original Fortran version of the matrix multiplication.
+*   **`matmul_improved_f(n, A, B, C)`:** (Extern "C") A Fortran function (defined elsewhere) representing the improved/optimized Fortran version of the matrix multiplication.
+*   **`CExampleBench(state)`:** A benchmark function that measures the performance of the `matmul` C function.
+*   **`CImprovedBench(state)`:** A benchmark function that measures the performance of the `matmul_improved` C function.
+*   **`FortranExampleBench(state)`:** A benchmark function that measures the performance of the `matmul_f` Fortran function.
+*   **`FortranImprovedBench(state)`:** A benchmark function that measures the performance of the `matmul_improved_f` Fortran function.
+
+## Important Variables/Constants
+
+*   **`N` (constexpr int):** Defines the dimension of the square matrices (N x N), set to `128`. The total number of elements in each matrix is `N * N`.
+*   **`OCB_ENABLE_C` (preprocessor macro):** If defined and true, the C benchmarks (`CExampleBench`, `CImprovedBench`) are compiled and registered.
+*   **`OCB_ENABLE_Fortran` (preprocessor macro):** If defined and true, the Fortran benchmarks (`FortranExampleBench`, `FortranImprovedBench`) are compiled and registered.
+
+## Usage Examples
+
+This file is compiled as part of the benchmark executable. The benchmarks are automatically registered and run by the Google Benchmark framework.
+
+```cpp
+// Benchmarks are registered like this:
+// OC_BENCHMARK("PWR043 C Example", CExampleBench);
+// OC_BENCHMARK("PWR043 C Improved", CImprovedBench);
+// OC_BENCHMARK("PWR043 Fortran Example", FortranExampleBench);
+// OC_BENCHMARK("PWR043 Fortran Improved", FortranImprovedBench);
+
+// The benchmarked functions (defined externally) are used as follows:
+// const double *A, *B; // initialized input matrices
+// double *C; // uninitialized memory for output matrix
+// matmul(N, A, B, C); // example matrix multiplication
+// matmul_improved(N, A, B, C); // improved matrix multiplication
+```
+
+## Dependencies and Interactions
+
+*   **`Benchmark.h`:** Includes utility functions like `OpenCatalog::CreateRandomVector`, `OpenCatalog::CreateUninitializedVector`, and the `OC_BENCHMARK` macro.
+*   **Google Benchmark library (`benchmark/benchmark.h` via `Benchmark.h`):** Provides the core framework for defining and running benchmarks.
+*   **External C/Fortran code:** The actual matrix multiplication functions (`matmul`, `matmul_improved`, etc.) are defined in other source files and linked.
+*   Conditional compilation based on `OCB_ENABLE_C` and `OCB_ENABLE_Fortran` macros allows selective testing.
+```

--- a/Benchmark/src/PWR046.cpp.md
+++ b/Benchmark/src/PWR046.cpp.md
@@ -1,0 +1,48 @@
+# PWR046.cpp
+
+## Overview
+
+This file defines benchmarks for `PWR046`, which focuses on computing the harmonic mean between pairs of elements from two input arrays `x` and `y`. It benchmarks C and Fortran implementations of an "example" version and an "improved" (solution) version of this computation.
+
+## Key Components
+
+*   **`compute_harmonic_mean_between_pairs(n, x, y, results)`:** (Extern "C") A C function (defined elsewhere) representing the original version of the harmonic mean calculation.
+*   **`compute_harmonic_mean_between_pairs_improved(n, x, y, results)`:** (Extern "C") A C function (defined elsewhere) representing the improved/optimized version of the harmonic mean calculation.
+*   **`compute_harmonic_mean_between_pairs_f(n, x, y, results)`:** (Extern "C") A Fortran function (defined elsewhere) representing the original Fortran version of the harmonic mean calculation.
+*   **`compute_harmonic_mean_between_pairs_improved_f(n, x, y, results)`:** (Extern "C") A Fortran function (defined elsewhere) representing the improved/optimized Fortran version of the harmonic mean calculation.
+*   **`CExampleBench(state)`:** A benchmark function that measures the performance of the `compute_harmonic_mean_between_pairs` C function.
+*   **`CImprovedBench(state)`:** A benchmark function that measures the performance of the `compute_harmonic_mean_between_pairs_improved` C function.
+*   **`FortranExampleBench(state)`:** A benchmark function that measures the performance of the `compute_harmonic_mean_between_pairs_f` Fortran function.
+*   **`FortranImprovedBench(state)`:** A benchmark function that measures the performance of the `compute_harmonic_mean_between_pairs_improved_f` Fortran function.
+
+## Important Variables/Constants
+
+*   **`N` (constexpr int):** Defines the size of the input arrays `x`, `y`, and `results`, set to `1024 * 1024`.
+*   **`OCB_ENABLE_C` (preprocessor macro):** If defined and true, the C benchmarks (`CExampleBench`, `CImprovedBench`) are compiled and registered.
+*   **`OCB_ENABLE_Fortran` (preprocessor macro):** If defined and true, the Fortran benchmarks (`FortranExampleBench`, `FortranImprovedBench`) are compiled and registered.
+
+## Usage Examples
+
+This file is compiled as part of the benchmark executable. The benchmarks are automatically registered and run by the Google Benchmark framework.
+
+```cpp
+// Benchmarks are registered like this:
+// OC_BENCHMARK("PWR046 C Example", CExampleBench);
+// OC_BENCHMARK("PWR046 C Improved", CImprovedBench);
+// OC_BENCHMARK("PWR046 Fortran Example", FortranExampleBench);
+// OC_BENCHMARK("PWR046 Fortran Improved", FortranImprovedBench);
+
+// The benchmarked functions (defined externally) are used as follows:
+// const double *x, *y; // initialized input arrays
+// double *results; // uninitialized memory for output array
+// compute_harmonic_mean_between_pairs(N, x, y, results);
+// compute_harmonic_mean_between_pairs_improved(N, x, y, results);
+```
+
+## Dependencies and Interactions
+
+*   **`Benchmark.h`:** Includes utility functions like `OpenCatalog::CreateRandomVector`, `OpenCatalog::CreateUninitializedVector`, and the `OC_BENCHMARK` macro.
+*   **Google Benchmark library (`benchmark/benchmark.h` via `Benchmark.h`):** Provides the core framework for defining and running benchmarks.
+*   **External C/Fortran code:** The actual harmonic mean calculation functions are defined in other source files and linked.
+*   Conditional compilation based on `OCB_ENABLE_C` and `OCB_ENABLE_Fortran` macros allows selective testing.
+```

--- a/Benchmark/src/PWR062.cpp.md
+++ b/Benchmark/src/PWR062.cpp.md
@@ -1,0 +1,48 @@
+# PWR062.cpp
+
+## Overview
+
+This file defines benchmarks for `PWR062`, which also focuses on matrix multiplication (`C = A * B`). It benchmarks C and Fortran implementations of an "example" version and an "improved" (solution) version. The result matrix `C` is initialized as uninitialized memory. This benchmark is structurally very similar to `PWR043.cpp`.
+
+## Key Components
+
+*   **`matmul(n, A, B, C)`:** (Extern "C") A C function (defined elsewhere) representing the original version of the matrix multiplication.
+*   **`matmul_improved(n, A, B, C)`:** (Extern "C") A C function (defined elsewhere) representing the improved/optimized version of the matrix multiplication.
+*   **`matmul_f(n, A, B, C)`:** (Extern "C") A Fortran function (defined elsewhere) representing the original Fortran version of the matrix multiplication.
+*   **`matmul_improved_f(n, A, B, C)`:** (Extern "C") A Fortran function (defined elsewhere) representing the improved/optimized Fortran version of the matrix multiplication.
+*   **`CExampleBench(state)`:** A benchmark function that measures the performance of the `matmul` C function.
+*   **`CImprovedBench(state)`:** A benchmark function that measures the performance of the `matmul_improved` C function.
+*   **`FortranExampleBench(state)`:** A benchmark function that measures the performance of the `matmul_f` Fortran function.
+*   **`FortranImprovedBench(state)`:** A benchmark function that measures the performance of the `matmul_improved_f` Fortran function.
+
+## Important Variables/Constants
+
+*   **`N` (constexpr int):** Defines the dimension of the square matrices (N x N), set to `128`. The total number of elements in each matrix is `N * N`.
+*   **`OCB_ENABLE_C` (preprocessor macro):** If defined and true, the C benchmarks (`CExampleBench`, `CImprovedBench`) are compiled and registered.
+*   **`OCB_ENABLE_Fortran` (preprocessor macro):** If defined and true, the Fortran benchmarks (`FortranExampleBench`, `FortranImprovedBench`) are compiled and registered.
+
+## Usage Examples
+
+This file is compiled as part of the benchmark executable. The benchmarks are automatically registered and run by the Google Benchmark framework.
+
+```cpp
+// Benchmarks are registered like this:
+// OC_BENCHMARK("PWR062 C Example", CExampleBench);
+// OC_BENCHMARK("PWR062 C Improved", CImprovedBench);
+// OC_BENCHMARK("PWR062 Fortran Example", FortranExampleBench);
+// OC_BENCHMARK("PWR062 Fortran Improved", FortranImprovedBench);
+
+// The benchmarked functions (defined externally) are used as follows:
+// const double *A, *B; // initialized input matrices
+// double *C; // uninitialized memory for output matrix
+// matmul(N, A, B, C); // example matrix multiplication
+// matmul_improved(N, A, B, C); // improved matrix multiplication
+```
+
+## Dependencies and Interactions
+
+*   **`Benchmark.h`:** Includes utility functions like `OpenCatalog::CreateRandomVector`, `OpenCatalog::CreateUninitializedVector`, and the `OC_BENCHMARK` macro.
+*   **Google Benchmark library (`benchmark/benchmark.h` via `Benchmark.h`):** Provides the core framework for defining and running benchmarks.
+*   **External C/Fortran code:** The actual matrix multiplication functions (`matmul`, `matmul_improved`, etc.) are defined in other source files and linked.
+*   Conditional compilation based on `OCB_ENABLE_C` and `OCB_ENABLE_Fortran` macros allows selective testing.
+```

--- a/Benchmark/src/PWR068.cpp.md
+++ b/Benchmark/src/PWR068.cpp.md
@@ -1,0 +1,41 @@
+# PWR068.cpp
+
+## Overview
+
+This file defines benchmarks for `PWR068`, which focuses on calculating Euclidean distances between pairs of points (X1,Y1) and (X2,Y2). It benchmarks only Fortran implementations: an "example" version and an "improved" version. The goal is to demonstrate that a suggested code modernization (presumably in the "improved" version) does not incur a performance penalty.
+
+## Key Components
+
+*   **`calculate_euclidean_distances_f(n, X1, Y1, X2, Y2, distances)`:** (Extern "C") A Fortran function (defined elsewhere) representing the original version of the Euclidean distance calculation.
+*   **`calculate_euclidean_distances_improved_f(n, X1, Y1, X2, Y2, distances)`:** (Extern "C") A Fortran function (defined elsewhere) representing the improved/modernized version of the Euclidean distance calculation.
+*   **`FortranExampleBench(state)`:** A benchmark function that measures the performance of the `calculate_euclidean_distances_f` Fortran function.
+*   **`FortranImprovedBench(state)`:** A benchmark function that measures the performance of the `calculate_euclidean_distances_improved_f` Fortran function.
+
+## Important Variables/Constants
+
+*   **`N` (constexpr int):** Defines the number of points and the size of the `distances` array, set to `1024 * 1024`.
+*   **`OCB_ENABLE_Fortran` (preprocessor macro):** If defined and true, the Fortran benchmarks (`FortranExampleBench`, `FortranImprovedBench`) are compiled and registered. (Note: C benchmarks are not present in this file).
+
+## Usage Examples
+
+This file is compiled as part of the benchmark executable. The benchmarks are automatically registered and run by the Google Benchmark framework.
+
+```cpp
+// Benchmarks are registered like this:
+// OC_BENCHMARK("PWR068 Fortran Example", FortranExampleBench);
+// OC_BENCHMARK("PWR068 Fortran Improved", FortranImprovedBench);
+
+// The benchmarked functions (defined externally) are used as follows:
+// double *X1, *Y1, *X2, *Y2; // initialized input coordinate arrays
+// double *distances; // zero-initialized output array for distances
+// calculate_euclidean_distances_f(N, X1, Y1, X2, Y2, distances);
+// calculate_euclidean_distances_improved_f(N, X1, Y1, X2, Y2, distances);
+```
+
+## Dependencies and Interactions
+
+*   **`Benchmark.h`:** Includes utility functions like `OpenCatalog::CreateRandomVector`, `OpenCatalog::CreateZeroVector`, and the `OC_BENCHMARK` macro.
+*   **Google Benchmark library (`benchmark/benchmark.h` via `Benchmark.h`):** Provides the core framework for defining and running benchmarks.
+*   **External Fortran code:** The actual Euclidean distance calculation functions are defined in other source files and linked.
+*   Conditional compilation based on `OCB_ENABLE_Fortran` macro allows selective testing of Fortran versions. No C counterparts are benchmarked in this file.
+```

--- a/Benchmark/src/PWR069.cpp.md
+++ b/Benchmark/src/PWR069.cpp.md
@@ -1,0 +1,41 @@
+# PWR069.cpp
+
+## Overview
+
+This file defines benchmarks for `PWR069`, focusing on calculating Euclidean distances between pairs of points (X1,Y1) and (X2,Y2). It benchmarks only Fortran implementations: an "example" version and an "improved" version. Similar to `PWR068`, the goal is to demonstrate that a suggested code modernization in the "improved" version does not incur a performance penalty. This file is structurally identical to `PWR068.cpp`.
+
+## Key Components
+
+*   **`calculate_euclidean_distances_f(n, X1, Y1, X2, Y2, distances)`:** (Extern "C") A Fortran function (defined elsewhere) representing the original version of the Euclidean distance calculation.
+*   **`calculate_euclidean_distances_improved_f(n, X1, Y1, X2, Y2, distances)`:** (Extern "C") A Fortran function (defined elsewhere) representing the improved/modernized version of the Euclidean distance calculation.
+*   **`FortranExampleBench(state)`:** A benchmark function that measures the performance of the `calculate_euclidean_distances_f` Fortran function.
+*   **`FortranImprovedBench(state)`:** A benchmark function that measures the performance of the `calculate_euclidean_distances_improved_f` Fortran function.
+
+## Important Variables/Constants
+
+*   **`N` (constexpr int):** Defines the number of points and the size of the `distances` array, set to `1024 * 1024`.
+*   **`OCB_ENABLE_Fortran` (preprocessor macro):** If defined and true, the Fortran benchmarks (`FortranExampleBench`, `FortranImprovedBench`) are compiled and registered. (Note: C benchmarks are not present in this file).
+
+## Usage Examples
+
+This file is compiled as part of the benchmark executable. The benchmarks are automatically registered and run by the Google Benchmark framework.
+
+```cpp
+// Benchmarks are registered like this:
+// OC_BENCHMARK("PWR069 Fortran Example", FortranExampleBench);
+// OC_BENCHMARK("PWR069 Fortran Improved", FortranImprovedBench);
+
+// The benchmarked functions (defined externally) are used as follows:
+// double *X1, *Y1, *X2, *Y2; // initialized input coordinate arrays
+// double *distances; // zero-initialized output array for distances
+// calculate_euclidean_distances_f(N, X1, Y1, X2, Y2, distances);
+// calculate_euclidean_distances_improved_f(N, X1, Y1, X2, Y2, distances);
+```
+
+## Dependencies and Interactions
+
+*   **`Benchmark.h`:** Includes utility functions like `OpenCatalog::CreateRandomVector`, `OpenCatalog::CreateZeroVector`, and the `OC_BENCHMARK` macro.
+*   **Google Benchmark library (`benchmark/benchmark.h` via `Benchmark.h`):** Provides the core framework for defining and running benchmarks.
+*   **External Fortran code:** The actual Euclidean distance calculation functions are defined in other source files and linked.
+*   Conditional compilation based on `OCB_ENABLE_Fortran` macro allows selective testing of Fortran versions. No C counterparts are benchmarked in this file.
+```

--- a/Benchmark/src/PWR070.cpp.md
+++ b/Benchmark/src/PWR070.cpp.md
@@ -1,0 +1,42 @@
+# PWR070.cpp
+
+## Overview
+
+This file defines benchmarks for `PWR070`, which deals with clamping data points at even indices within an array `X` to a specified minimum (`min_value`) and maximum (`max_value`). It benchmarks only Fortran implementations: an "example" version and an "improved" version of this operation.
+
+## Key Components
+
+*   **`clamp_even_data_points_f(n, X, min_value, max_value)`:** (Extern "C") A Fortran function (defined elsewhere) representing the original version of the clamping operation.
+*   **`clamp_even_data_points_improved_f(n, X, min_value, max_value)`:** (Extern "C") A Fortran function (defined elsewhere) representing the improved/optimized version of the clamping operation.
+*   **`FortranExampleBench(state)`:** A benchmark function that measures the performance of the `clamp_even_data_points_f` Fortran function.
+*   **`FortranImprovedBench(state)`:** A benchmark function that measures the performance of the `clamp_even_data_points_improved_f` Fortran function.
+
+## Important Variables/Constants
+
+*   **`N` (constexpr int):** Defines the size of the input array `X`, set to `1024 * 1024`.
+*   **`MIN_VALUE` (constexpr double):** The minimum value to which data points are clamped, set to `2.71`.
+*   **`MAX_VALUE` (constexpr double):** The maximum value to which data points are clamped, set to `3.14`.
+*   **`OCB_ENABLE_Fortran` (preprocessor macro):** If defined and true, the Fortran benchmarks (`FortranExampleBench`, `FortranImprovedBench`) are compiled and registered. (Note: C benchmarks are not present in this file).
+
+## Usage Examples
+
+This file is compiled as part of the benchmark executable. The benchmarks are automatically registered and run by the Google Benchmark framework. The input array `X` is modified in-place.
+
+```cpp
+// Benchmarks are registered like this:
+// OC_BENCHMARK("PWR070 Fortran Example", FortranExampleBench);
+// OC_BENCHMARK("PWR070 Fortran Improved", FortranImprovedBench);
+
+// The benchmarked functions (defined externally) are used as follows:
+// double *X; // initialized input array (will be modified)
+// clamp_even_data_points_f(N, X, MIN_VALUE, MAX_VALUE);
+// clamp_even_data_points_improved_f(N, X, MIN_VALUE, MAX_VALUE);
+```
+
+## Dependencies and Interactions
+
+*   **`Benchmark.h`:** Includes utility functions like `OpenCatalog::CreateRandomVector` and the `OC_BENCHMARK` macro.
+*   **Google Benchmark library (`benchmark/benchmark.h` via `Benchmark.h`):** Provides the core framework for defining and running benchmarks.
+*   **External Fortran code:** The actual clamping functions are defined in other source files and linked.
+*   Conditional compilation based on `OCB_ENABLE_Fortran` macro allows selective testing of Fortran versions. No C counterparts are benchmarked in this file.
+```

--- a/Benchmark/src/PWR071.cpp.md
+++ b/Benchmark/src/PWR071.cpp.md
@@ -1,0 +1,41 @@
+# PWR071.cpp
+
+## Overview
+
+This file defines benchmarks for `PWR071`, focusing on calculating Euclidean distances between pairs of points (X1,Y1) and (X2,Y2). It benchmarks only Fortran implementations: an "example" version and an "improved" version. Similar to `PWR068` and `PWR069`, the goal is to demonstrate that a suggested code modernization in the "improved" version does not incur a performance penalty. This file is structurally identical to `PWR068.cpp` and `PWR069.cpp`.
+
+## Key Components
+
+*   **`calculate_euclidean_distances_f(n, X1, Y1, X2, Y2, distances)`:** (Extern "C") A Fortran function (defined elsewhere) representing the original version of the Euclidean distance calculation.
+*   **`calculate_euclidean_distances_improved_f(n, X1, Y1, X2, Y2, distances)`:** (Extern "C") A Fortran function (defined elsewhere) representing the improved/modernized version of the Euclidean distance calculation.
+*   **`FortranExampleBench(state)`:** A benchmark function that measures the performance of the `calculate_euclidean_distances_f` Fortran function.
+*   **`FortranImprovedBench(state)`:** A benchmark function that measures the performance of the `calculate_euclidean_distances_improved_f` Fortran function.
+
+## Important Variables/Constants
+
+*   **`N` (constexpr int):** Defines the number of points and the size of the `distances` array, set to `1024 * 1024`.
+*   **`OCB_ENABLE_Fortran` (preprocessor macro):** If defined and true, the Fortran benchmarks (`FortranExampleBench`, `FortranImprovedBench`) are compiled and registered. (Note: C benchmarks are not present in this file).
+
+## Usage Examples
+
+This file is compiled as part of the benchmark executable. The benchmarks are automatically registered and run by the Google Benchmark framework.
+
+```cpp
+// Benchmarks are registered like this:
+// OC_BENCHMARK("PWR071 Fortran Example", FortranExampleBench);
+// OC_BENCHMARK("PWR071 Fortran Improved", FortranImprovedBench);
+
+// The benchmarked functions (defined externally) are used as follows:
+// double *X1, *Y1, *X2, *Y2; // initialized input coordinate arrays
+// double *distances; // zero-initialized output array for distances
+// calculate_euclidean_distances_f(N, X1, Y1, X2, Y2, distances);
+// calculate_euclidean_distances_improved_f(N, X1, Y1, X2, Y2, distances);
+```
+
+## Dependencies and Interactions
+
+*   **`Benchmark.h`:** Includes utility functions like `OpenCatalog::CreateRandomVector`, `OpenCatalog::CreateZeroVector`, and the `OC_BENCHMARK` macro.
+*   **Google Benchmark library (`benchmark/benchmark.h` via `Benchmark.h`):** Provides the core framework for defining and running benchmarks.
+*   **External Fortran code:** The actual Euclidean distance calculation functions are defined in other source files and linked.
+*   Conditional compilation based on `OCB_ENABLE_Fortran` macro allows selective testing of Fortran versions. No C counterparts are benchmarked in this file.
+```

--- a/Benchmark/src/PWR072.cpp.md
+++ b/Benchmark/src/PWR072.cpp.md
@@ -1,0 +1,40 @@
+# PWR072.cpp
+
+## Overview
+
+This file defines benchmarks for `PWR072`, which focuses on computing the final moving average of a data series `X`. It benchmarks only Fortran implementations: an "example" version and an "improved" version of this calculation. The goal is to show that a suggested code modernization in the "improved" version does not negatively impact performance.
+
+## Key Components
+
+*   **`compute_final_moving_average_f(n, X)`:** (Extern "C") A Fortran function (defined elsewhere) representing the original version of the moving average calculation. It returns a single `double` value.
+*   **`compute_final_moving_average_improved_f(n, X)`:** (Extern "C") A Fortran function (defined elsewhere) representing the improved/modernized version of the moving average calculation. It returns a single `double` value.
+*   **`FortranExampleBench(state)`:** A benchmark function that measures the performance of the `compute_final_moving_average_f` Fortran function.
+*   **`FortranImprovedBench(state)`:** A benchmark function that measures the performance of the `compute_final_moving_average_improved_f` Fortran function.
+
+## Important Variables/Constants
+
+*   **`N` (constexpr int):** Defines the size of the input array `X`, set to `1024 * 1024`.
+*   **`OCB_ENABLE_Fortran` (preprocessor macro):** If defined and true, the Fortran benchmarks (`FortranExampleBench`, `FortranImprovedBench`) are compiled and registered. (Note: C benchmarks are not present in this file).
+
+## Usage Examples
+
+This file is compiled as part of the benchmark executable. The benchmarks are automatically registered and run by the Google Benchmark framework. The input array `X` is passed to the function, and a single double result is returned.
+
+```cpp
+// Benchmarks are registered like this:
+// OC_BENCHMARK("PWR072 Fortran Example", FortranExampleBench);
+// OC_BENCHMARK("PWR072 Fortran Improved", FortranImprovedBench);
+
+// The benchmarked functions (defined externally) are used as follows:
+// double *X; // initialized input array
+// double moving_avg_example = compute_final_moving_average_f(N, X);
+// double moving_avg_improved = compute_final_moving_average_improved_f(N, X);
+```
+
+## Dependencies and Interactions
+
+*   **`Benchmark.h`:** Includes utility functions like `OpenCatalog::CreateRandomVector` and the `OC_BENCHMARK` macro.
+*   **Google Benchmark library (`benchmark/benchmark.h` via `Benchmark.h`):** Provides the core framework for defining and running benchmarks.
+*   **External Fortran code:** The actual moving average calculation functions are defined in other source files and linked.
+*   Conditional compilation based on `OCB_ENABLE_Fortran` macro allows selective testing of Fortran versions. No C counterparts are benchmarked in this file.
+```

--- a/Benchmark/src/PWR073.cpp.md
+++ b/Benchmark/src/PWR073.cpp.md
@@ -1,0 +1,43 @@
+# PWR073.cpp
+
+## Overview
+
+This file defines benchmarks for `PWR073`, which focuses on transforming a vector `X` into a `result` vector using a linear transformation defined by coefficients `coeff_a` and `coeff_b`. It benchmarks only Fortran implementations: an "example" version and an "improved" version of this transformation. The stated goal is to show that a suggested code modernization in the "improved" version does not negatively impact performance.
+
+## Key Components
+
+*   **`transform_vector_f(n, X, result, coeff_a, coeff_b)`:** (Extern "C") A Fortran function (defined elsewhere) representing the original version of the vector transformation.
+*   **`transform_vector_improved_f(n, X, result, coeff_a, coeff_b)`:** (Extern "C") A Fortran function (defined elsewhere) representing the improved/modernized version of the vector transformation.
+*   **`FortranExampleBench(state)`:** A benchmark function that measures the performance of the `transform_vector_f` Fortran function.
+*   **`FortranImprovedBench(state)`:** A benchmark function that measures the performance of the `transform_vector_improved_f` Fortran function.
+
+## Important Variables/Constants
+
+*   **`N` (constexpr int):** Defines the size of the input array `X` and the output array `result`, set to `1024 * 1024`.
+*   **`COEFF_A` (constexpr double):** The first coefficient for the transformation, set to `4.5`.
+*   **`COEFF_B` (constexpr double):** The second coefficient for the transformation, set to `0.73`.
+*   **`OCB_ENABLE_Fortran` (preprocessor macro):** If defined and true, the Fortran benchmarks (`FortranExampleBench`, `FortranImprovedBench`) are compiled and registered. (Note: C benchmarks are not present in this file).
+
+## Usage Examples
+
+This file is compiled as part of the benchmark executable. The benchmarks are automatically registered and run by the Google Benchmark framework.
+
+```cpp
+// Benchmarks are registered like this:
+// OC_BENCHMARK("PWR073 Fortran Example", FortranExampleBench);
+// OC_BENCHMARK("PWR073 Fortran Improved", FortranImprovedBench);
+
+// The benchmarked functions (defined externally) are used as follows:
+// double *X; // initialized input array
+// double *result; // zero-initialized output array
+// transform_vector_f(N, X, result, COEFF_A, COEFF_B);
+// transform_vector_improved_f(N, X, result, COEFF_A, COEFF_B);
+```
+
+## Dependencies and Interactions
+
+*   **`Benchmark.h`:** Includes utility functions like `OpenCatalog::CreateRandomVector`, `OpenCatalog::CreateZeroVector`, and the `OC_BENCHMARK` macro.
+*   **Google Benchmark library (`benchmark/benchmark.h` via `Benchmark.h`):** Provides the core framework for defining and running benchmarks.
+*   **External Fortran code:** The actual vector transformation functions are defined in other source files and linked.
+*   Conditional compilation based on `OCB_ENABLE_Fortran` macro allows selective testing of Fortran versions. No C counterparts are benchmarked in this file.
+```

--- a/Benchmark/src/PWR075.cpp.md
+++ b/Benchmark/src/PWR075.cpp.md
@@ -1,0 +1,42 @@
+# PWR075.cpp
+
+## Overview
+
+This file defines benchmarks for `PWR075`, which involves calculating distances based on two sets of points (P1, P2, likely angles or coordinates) and a corresponding set of radiuses. It benchmarks only Fortran implementations: an "example" version and an "improved" version. The objective is to demonstrate that a suggested code modernization in the "improved" version maintains performance.
+
+## Key Components
+
+*   **`calculate_distances_f(n, P1, P2, radiuses, distances)`:** (Extern "C") A Fortran function (defined elsewhere) representing the original version of the distance calculation.
+*   **`calculate_distances_improved_f(n, P1, P2, radiuses, distances)`:** (Extern "C") A Fortran function (defined elsewhere) representing the improved/modernized version of the distance calculation.
+*   **`FortranExampleBench(state)`:** A benchmark function that measures the performance of the `calculate_distances_f` Fortran function.
+*   **`FortranImprovedBench(state)`:** A benchmark function that measures the performance of the `calculate_distances_improved_f` Fortran function.
+
+## Important Variables/Constants
+
+*   **`N` (constexpr int):** Defines the size of the input arrays `P1`, `P2`, `radiuses`, and the output array `distances`. Set to `1024 * 64`.
+*   **`OCB_ENABLE_Fortran` (preprocessor macro):** If defined and true, the Fortran benchmarks (`FortranExampleBench`, `FortranImprovedBench`) are compiled and registered. (Note: C benchmarks are not present in this file).
+*   Input arrays `P1` and `P2` are populated with random numbers between 0.0 and 360.0, suggesting they might represent angles.
+
+## Usage Examples
+
+This file is compiled as part of the benchmark executable. The benchmarks are automatically registered and run by the Google Benchmark framework.
+
+```cpp
+// Benchmarks are registered like this:
+// OC_BENCHMARK("PWR075 Fortran Example", FortranExampleBench);
+// OC_BENCHMARK("PWR075 Fortran Improved", FortranImprovedBench);
+
+// The benchmarked functions (defined externally) are used as follows:
+// double *P1, *P2, *radiuses; // initialized input arrays
+// double *distances; // zero-initialized output array
+// calculate_distances_f(N, P1, P2, radiuses, distances);
+// calculate_distances_improved_f(N, P1, P2, radiuses, distances);
+```
+
+## Dependencies and Interactions
+
+*   **`Benchmark.h`:** Includes utility functions like `OpenCatalog::CreateRandomVector`, `OpenCatalog::CreateZeroVector`, and the `OC_BENCHMARK` macro.
+*   **Google Benchmark library (`benchmark/benchmark.h` via `Benchmark.h`):** Provides the core framework for defining and running benchmarks.
+*   **External Fortran code:** The actual distance calculation functions are defined in other source files and linked.
+*   Conditional compilation based on `OCB_ENABLE_Fortran` macro allows selective testing of Fortran versions. No C counterparts are benchmarked in this file.
+```

--- a/Benchmark/src/PWR079.cpp.md
+++ b/Benchmark/src/PWR079.cpp.md
@@ -1,0 +1,49 @@
+# PWR079.cpp
+
+## Overview
+
+This file defines benchmarks for `PWR079`, which focuses on summing all elements in a given array. It benchmarks C and Fortran implementations of an "example" version and an "improved" (solution) version of this summation. The objective is to show that a suggested check or optimization in the "improved" version does not lead to performance degradation.
+
+## Key Components
+
+*   **`sum_array(n, array)`:** (Extern "C") A C function (defined elsewhere) representing the original version of the array summation. Returns the sum as a `double`.
+*   **`sum_array_improved(n, array)`:** (Extern "C") A C function (defined elsewhere) representing the improved/optimized version of the array summation. Returns the sum as a `double`.
+*   **`sum_array_f(n, array)`:** (Extern "C") A Fortran function (defined elsewhere) representing the original Fortran version of the array summation. Returns the sum as a `double`.
+*   **`sum_array_improved_f(n, array)`:** (Extern "C") A Fortran function (defined elsewhere) representing the improved/optimized Fortran version of the array summation. Returns the sum as a `double`.
+*   **`CExampleBench(state)`:** A benchmark function that measures the performance of the `sum_array` C function.
+*   **`CImprovedBench(state)`:** A benchmark function that measures the performance of the `sum_array_improved` C function.
+*   **`FortranExampleBench(state)`:** A benchmark function that measures the performance of the `sum_array_f` Fortran function.
+*   **`FortranImprovedBench(state)`:** A benchmark function that measures the performance of the `sum_array_improved_f` Fortran function.
+
+## Important Variables/Constants
+
+*   **`N` (constexpr int):** Defines the size of the input `array`, set to `1024 * 1024`.
+*   **`OCB_ENABLE_C` (preprocessor macro):** If defined and true, the C benchmarks (`CExampleBench`, `CImprovedBench`) are compiled and registered.
+*   **`OCB_ENABLE_Fortran` (preprocessor macro):** If defined and true, the Fortran benchmarks (`FortranExampleBench`, `FortranImprovedBench`) are compiled and registered.
+
+## Usage Examples
+
+This file is compiled as part of the benchmark executable. The benchmarks are automatically registered and run by the Google Benchmark framework.
+
+```cpp
+// Benchmarks are registered like this:
+// OC_BENCHMARK("PWR079 C Example", CExampleBench);
+// OC_BENCHMARK("PWR079 C Improved", CImprovedBench);
+// OC_BENCHMARK("PWR079 Fortran Example", FortranExampleBench);
+// OC_BENCHMARK("PWR079 Fortran Improved", FortranImprovedBench);
+
+// The benchmarked functions (defined externally) are used as follows:
+// const double *array; // initialized input array
+// double sum_c_example = sum_array(N, array);
+// double sum_c_improved = sum_array_improved(N, array);
+// double sum_f_example = sum_array_f(N, array);
+// double sum_f_improved = sum_array_improved_f(N, array);
+```
+
+## Dependencies and Interactions
+
+*   **`Benchmark.h`:** Includes utility functions like `OpenCatalog::CreateRandomVector` and the `OC_BENCHMARK` macro.
+*   **Google Benchmark library (`benchmark/benchmark.h` via `Benchmark.h`):** Provides the core framework for defining and running benchmarks.
+*   **External C/Fortran code:** The actual array summation functions are defined in other source files and linked.
+*   Conditional compilation based on `OCB_ENABLE_C` and `OCB_ENABLE_Fortran` macros allows selective testing.
+```

--- a/Benchmark/src/main.cpp.md
+++ b/Benchmark/src/main.cpp.md
@@ -1,0 +1,31 @@
+# main.cpp
+
+## Overview
+
+This file is the main entry point for the benchmark executable. It uses the Google Benchmark library's `BENCHMARK_MAIN()` macro to generate the main function that runs all registered benchmarks.
+
+## Key Components
+
+*   **`BENCHMARK_MAIN()`:** A macro provided by the Google Benchmark library. When invoked, it generates the `main()` function necessary to initialize and run all defined benchmarks in the project.
+
+## Important Variables/Constants
+
+*   None.
+
+## Usage Examples
+
+This file itself does not provide components to be used by other modules. Instead, it compiles into the main executable that runs benchmarks.
+
+To run the benchmarks, compile this file along with the benchmark definition files (e.g., `PWR*.cpp` files) and the Google Benchmark library. Then, execute the resulting binary.
+
+```bash
+# Example (pseudo-commands, actual compilation may vary)
+# g++ -std=c++11 main.cpp PWR003.cpp ... -lbenchmark -lpthread -o benchmark_runner
+# ./benchmark_runner
+```
+
+## Dependencies and Interactions
+
+*   **`benchmark/benchmark.h`:** This file directly depends on the Google Benchmark library, specifically for the `BENCHMARK_MAIN()` macro.
+*   **Benchmark Definition Files (e.g., `PWR*.cpp`, `Benchmark.h`):** While not a direct include dependency in `main.cpp` itself, the executable produced relies on other `.cpp` files where benchmarks are defined using macros like `BENCHMARK()` or `OC_BENCHMARK()`. The linker will combine these definitions with the `main` function generated here.
+```

--- a/documentation_template.md
+++ b/documentation_template.md
@@ -1,0 +1,33 @@
+# [File Name]
+
+## Overview
+
+[Brief description of what the code file does and its role within the larger project.]
+
+## Key Components
+
+[List of the primary functions, classes, or modules defined in the file, with a short description of each.]
+
+*   **[Component Name 1]:** [Description]
+*   **[Component Name 2]:** [Description]
+*   ...
+
+## Important Variables/Constants
+
+[Descriptions of any critical variables or constants defined in the file that affect its behavior.]
+
+*   **[Variable/Constant Name 1]:** [Description]
+*   **[Variable/Constant Name 2]:** [Description]
+*   ...
+
+## Usage Examples
+
+[If applicable, provide examples or code snippets demonstrating how to use the functions, classes, or modules in the file.]
+
+```cpp
+// Example code
+```
+
+## Dependencies and Interactions
+
+[Notes on any dependencies the file has on other parts of the system or external libraries, and how it interacts with other components.]


### PR DESCRIPTION
This commit introduces Markdown documentation for the C++ source files located in the `Benchmark/src/` directory. Each `.cpp` and `.h` file now has a corresponding `.md` file providing an overview, key components, usage examples, and dependencies.

The following files were documented:
- Benchmark.h
- main.cpp
- PWR003.cpp
- PWR022.cpp
- PWR031.cpp
- PWR032.cpp
- PWR037.cpp
- PWR039.cpp
- PWR043.cpp
- PWR046.cpp
- PWR062.cpp
- PWR068.cpp
- PWR069.cpp
- PWR070.cpp
- PWR071.cpp
- PWR072.cpp
- PWR073.cpp
- PWR075.cpp
- PWR079.cpp

A template was used to ensure consistency across the documentation files. These documents are intended for developers maintaining or extending the benchmark suite.